### PR TITLE
Add optional node sorting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,8 @@ Run the tool without a capture file to sniff packets continuously. The diagram w
 ./src/network_sankey.py --interface en0 --dash --direction both
 ```
 
+Pass the `--sort-nodes` flag to alphabetically sort nodes by name.
+
 The figure starts empty and populates as traffic is captured. You can control how many packets are processed in each batch with `--batch-size`.
 Use the **Pause** button to temporarily stop capturing traffic and **Clear** to reset the diagram.
 
@@ -34,10 +36,10 @@ Use the **Pause** button to temporarily stop capturing traffic and **Clear** to 
 - Tooltips cover the flows
 - Provide a rolling window of the capture (eg last 30 seconds)
 - Display a diagram in native GUI without using browser
-- Sort nodes
 
 ## Done
 - Consistent node colors between updates
 - Unified diagram ( in -> interface -> out)
 - Capture pause/resume and clear buttons
 - Display a running count of packets/frames/bytes in/out
+- Sort nodes alphabetically with `--sort-nodes`

--- a/src/network_sankey.py
+++ b/src/network_sankey.py
@@ -162,10 +162,18 @@ def compute_sankey_data(
             return [], [], [], [], None
 
         path_pairs = list(pairwise(values["path"]))
-        all_nodes = pd.concat([df[col] for col in values["path"]]).dropna().unique()
-        if sort_nodes:
-            all_nodes = sorted(all_nodes)
-        node_indices = {node: idx for idx, node in enumerate(all_nodes)}
+        all_nodes: list[str] = []
+        node_indices: dict[str, int] = {}
+        for col in values["path"]:
+            if col not in df:
+                continue
+            nodes = df[col].dropna().unique()
+            if sort_nodes:
+                nodes = sorted(nodes)
+            for node in nodes:
+                if node not in node_indices:
+                    node_indices[node] = len(all_nodes)
+                    all_nodes.append(node)
 
         combined_df = pd.DataFrame()
         for source, target in path_pairs:
@@ -263,10 +271,27 @@ def compute_sankey_data(
         ignore_index=True,
     )
 
-    all_nodes = pd.concat([combined_df["Source"], combined_df["Target"]]).dropna().unique()
-    if sort_nodes:
-        all_nodes = sorted(all_nodes)
-    node_indices = {node: idx for idx, node in enumerate(all_nodes)}
+    all_nodes: list[str] = []
+    node_indices: dict[str, int] = {}
+    for col in inbound_path:
+        if col in inbound_df:
+            nodes = inbound_df[col].dropna().unique()
+            if sort_nodes:
+                nodes = sorted(nodes)
+            for node in nodes:
+                if node not in node_indices:
+                    node_indices[node] = len(all_nodes)
+                    all_nodes.append(node)
+    for col in outbound_path:
+        if col in outbound_df:
+            nodes = outbound_df[col].dropna().unique()
+            if sort_nodes:
+                nodes = sorted(nodes)
+            for node in nodes:
+                if node not in node_indices:
+                    node_indices[node] = len(all_nodes)
+                    all_nodes.append(node)
+
     sources = combined_df["Source"].map(node_indices).tolist()
     targets = combined_df["Target"].map(node_indices).tolist()
     values_list = combined_df["Value"].tolist()


### PR DESCRIPTION
## Summary
- add `--sort-nodes` CLI option
- implement sorting logic in Sankey computation
- propagate sort flag to figure creation and updates
- document the new option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685dad8d178083338b7e474e543da7e1