### PR TITLE
Add pytest-cov plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 dev = [
     # Testing
     "unittest-xml-reporting",
+    "pytest-cov",
     # Linting and type checking
     "mypy",
     "ruff >= 0.9.2",
@@ -114,6 +115,7 @@ indent-style = "space"
 line-ending = "auto"
 docstring-code-format = true
 docstring-code-line-length = 100
+
 
 [tool.pytest.ini_options]
 addopts = "--cov --cov-report html --cov-report term-missing --cov-fail-under 95"


### PR DESCRIPTION
## Summary
- include `pytest-cov` in dev dependencies
- restore coverage options for pytest

## Testing
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_686282b2ed488333b40c9e9880f84e7c